### PR TITLE
Update add1.c

### DIFF
--- a/book/add1.c
+++ b/book/add1.c
@@ -10,8 +10,7 @@ int main(void)
 
 	while(*t)			/* loop through the whole string */
 	{
-		addch(*t);		/* put one char to curscr */
-		t++;			/* increment the pointer */
+		addch(*t++);		/* put one char to curscr */
 		refresh();		/* update the screen */
 		napms(100);		/* delay a bit to see the display */
 	}				/* end while */


### PR DESCRIPTION
A trivial adjustment, but generally speaking, there is no need to write *t then t++ when you can simplify that.

Individual expressions like the following are invaluable code shortcuts:
*t++ access character then increment pointer for the next expression (same as { char = *t; t++; } )
(*t)++ increment the accessed character itself (same as { char = *t ; *t += 1; } )
++*t also increment the character itself, but the incremented character is used mid-expression, rather than for a later one
*++t increment the pointer immediately then access the character (which will be the character of the incremented pointer)